### PR TITLE
Add missing runtime dependency on rosbridge_server

### DIFF
--- a/swri_profiler/package.xml
+++ b/swri_profiler/package.xml
@@ -14,6 +14,7 @@
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
   <depend>swri_profiler_msgs</depend>
+  <exec_depend>rosbridge_server</exec_depend>
 
   <export>
   </export>


### PR DESCRIPTION
Since the launch files of swri_profiler refer to rosbridge_server, it's an exec_depend.
