### PR TITLE
Correct license tag in package.xml.

### DIFF
--- a/swri_profiler/package.xml
+++ b/swri_profiler/package.xml
@@ -7,7 +7,7 @@
   </description>
 
   <maintainer email="preed@swri.org">P. J. Reed</maintainer>
-  <license>Copyright SwRI</license>
+  <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/swri_profiler_msgs/package.xml
+++ b/swri_profiler_msgs/package.xml
@@ -5,7 +5,7 @@
     Messages for the swri_profiler tool.
   </description>
   <maintainer email="preed@swri.org">P. J. Reed</maintainer>
-  <license>Copyright SwRI</license>
+  <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>


### PR DESCRIPTION
`license` tag in package.xml is for describing license (e.g. [REP127](http://www.ros.org/reps/rep-0127.html#license-multiple-but-at-least-one)), NOT for copyrights. It's not clear to me if there's any license declaration within this package, but I see the [LICENSE file](https://github.com/swri-robotics/swri_profiler/blob/cf4c44016f5b9ab5367639b20a6d4e4daa5b983f/LICENSE), github.com suggests BSD (see the image below, so all package.xml files are updated accordingly.

![screenshot from 2018-06-07 12-01-27](https://user-images.githubusercontent.com/1840401/41120668-0a1a67ac-6a4b-11e8-901d-f783a85c0f56.png)
