### PR TITLE
Clean up Qt usage in CMakeLists.txt

### DIFF
--- a/swri_profiler_tools/CMakeLists.txt
+++ b/swri_profiler_tools/CMakeLists.txt
@@ -15,37 +15,18 @@ set(RUNTIME_DEPS
 find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})
 
 ### QT ###
-if("$ENV{ROS_DISTRO}" STRLESS "kinetic")
-  find_package(Qt4 COMPONENTS REQUIRED QtCore QtGui)
-  set(Qt_FOUND TRUE)
-  set(Qt_INCLUDE_DIRS "${QT_INCLUDE_DIR};${QT_QTCORE_INCLUDE_DIR};${QT_QTGUI_INCLUDE_DIR}")
-  set(Qt_LIBRARIES "${QT_QTCORE_LIBRARY};${QT_QTGUI_LIBRARY}")
-  set(Qt_LIBS
-      Qt4::QtCore
-      Qt4::QtGui
-      )
-else()
-  find_package(Qt5Core REQUIRED)
-  find_package(Qt5Gui REQUIRED)
-  find_package(Qt5Widgets REQUIRED)
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-  # Not necessary for this project, but these Qt_* variables must be set in order
-  # for catkin_package to DEPENDS on Qt
-  set(Qt_FOUND TRUE)
-  set(Qt_INCLUDE_DIRS "${Qt5Core_INCLUDE_DIRS};${Qt5Gui_INCLUDE_DIRS};${Qt5Widgets_INCLUDE_DIRS}")
-  set(Qt_LIBRARIES "${Qt5Core_LIBRARIES};${Qt5Gui_LIBRARIES};${Qt5Widgets_LIBRARIES}")
-endif()
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Gui REQUIRED)
+find_package(Qt5Widgets REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include_directories(include
   ${catkin_INCLUDE_DIRS}
-  ${Qt_INCLUDE_DIRS}
 )
 
 catkin_package(
   CATKIN_DEPENDS ${RUNTIME_DEPS}
   INCLUDE_DIRS include
-  DEPENDS Qt
   LIBRARIES ${PROJECT_NAME}
 )
 
@@ -81,15 +62,9 @@ set(SRC_FILES
   src/time_plot_widget.cpp
 )
 
-if("$ENV{ROS_DISTRO}" STRLESS "kinetic")
-  qt4_add_resources(RCC_SRCS resources/images.qrc)
-  qt4_wrap_ui(SRC_FILES ${UI_FILES})
-  qt4_wrap_cpp(SRC_FILES ${MOC_HEADER_FILES})
-else()
-  qt5_add_resources(RCC_SRCS resources/images.qrc)
-  qt5_wrap_ui(SRC_FILES ${UI_FILES})
-  qt5_wrap_cpp(SRC_FILES ${MOC_HEADER_FILES})
-endif()
+qt5_add_resources(RCC_SRCS resources/images.qrc)
+qt5_wrap_ui(SRC_FILES ${UI_FILES})
+qt5_wrap_cpp(SRC_FILES ${MOC_HEADER_FILES})
 
 add_executable(profiler 
   src/main.cpp
@@ -98,12 +73,9 @@ add_executable(profiler
 )
 target_link_libraries(profiler
   ${catkin_LIBRARIES}
-  ${Qt_LIBRARIES}
-)
-
-add_dependencies(profiler swri_profiler_msgs_generate_messages_cpp)
-set_target_properties(profiler PROPERTIES
-  COMPILE_FLAGS "-std=c++0x"
+  Qt5::Core
+  Qt5::Gui
+  Qt5::Widgets
 )
 
 ### Install Test Node and Headers ###

--- a/swri_profiler_tools/include/swri_profiler_tools/profile.h
+++ b/swri_profiler_tools/include/swri_profiler_tools/profile.h
@@ -205,15 +205,15 @@ class Profile : public QObject
   ~Profile();
 
   void addData(const NewProfileDataVector &data);
-  const bool isValid() const { return profile_key_ >= 0; }
-  const int profileKey() const { return profile_key_; }
+  bool isValid() const { return profile_key_ >= 0; }
+  int profileKey() const { return profile_key_; }
 
   const QString& name() const { return name_; }
   void setName(const QString &name);
 
   const ProfileNode& node(int node_key) const;
   const ProfileNode& rootNode() const;
-  const int rootKey() const { return 0; }
+  int rootKey() const { return 0; }
   const std::vector<int>& nodeKeys() const;
   
  Q_SIGNALS:


### PR DESCRIPTION
swri_profiler_tools had quite a bit of code related to providing Qt4
compatibility which is no longer necessary, so it has been removed
for the sake of simplifying the build.